### PR TITLE
fix(npm/pnpm): corrects target command for create

### DIFF
--- a/lib/narn-lib.js
+++ b/lib/narn-lib.js
@@ -125,7 +125,7 @@ exports.getNpmArgs = (narnArgs, isPnpm = false) => {
         return result;
       }
     case "create":
-      npmTarget = "init";
+      npmTarget = "create";
       npmArgs = yarnSubCommands;
       break;
     case "publish":


### PR DESCRIPTION
The `create` commands in `yarn`, `npm`, and `pnpm` are all effectively the same, but the `npm`/`pnpm` target command was mistakenly set to align with `init` (which is also largely the same across package managers).